### PR TITLE
179 s report firmware version mismatch on connect

### DIFF
--- a/app/renderer/src/rest_api_wrapper.js
+++ b/app/renderer/src/rest_api_wrapper.js
@@ -15,10 +15,12 @@ class OpenTrons {
     return Vue.http
       .post(this.connectUrl, options)
       .then((response) => {
-        console.log('successfully connected...')
+        console.log(response.data)
         if (response.data.status === "success") {
+          console.log('successfully connected...')
           return true
         } else {
+          console.log('connection failed...')
           return false
         }
       }, (response) => {

--- a/server/main.py
+++ b/server/main.py
@@ -203,6 +203,20 @@ def get_coordinates():
     })
 
 
+@app.route("/robot/diagnostics")
+def get_diagnostics():
+    return flask.jsonify({
+        'diagnostics': robot.diagnostics()
+    })
+
+
+@app.route("/robot/versions")
+def get_versions():
+    return flask.jsonify({
+        'versions': robot.versions()
+    })
+
+
 @app.route("/robot/serial/connect", methods=["POST"])
 def connect_robot():
     port = request.json.get('port')

--- a/server/main.py
+++ b/server/main.py
@@ -205,14 +205,19 @@ def get_coordinates():
 
 @app.route("/robot/serial/connect", methods=["POST"])
 def connect_robot():
-    port = flask.request.args.get('port')
+    port = request.json.get('port')
+    options = request.json.get('options', {'limit_switches': False})
 
     status = 'success'
     data = None
 
     try:
-        Robot.get_instance().connect(port, options={'limit_switches': False})
+        robot = Robot.get_instance()
+        robot.connect(
+            port, options=options)
     except Exception as e:
+        # any robot version incompatibility will be caught here
+        robot.disconnect()
         status = 'error'
         data = str(e)
 

--- a/server/main.py
+++ b/server/main.py
@@ -235,6 +235,13 @@ def connect_robot():
         status = 'error'
         data = str(e)
 
+    return flask.jsonify({
+        'status': status,
+        'data': data
+    })
+
+
+def _start_connection_watcher():
     connection_state_watcher, watcher_should_run = BACKGROUND_TASKS.get(
         'CONNECTION_STATE_WATCHER',
         (None, None)
@@ -264,11 +271,6 @@ def connect_robot():
         connection_state_watcher,
         watcher_should_run
     )
-
-    return flask.jsonify({
-        'status': status,
-        'data': data
-    })
 
 
 @app.route("/robot/serial/disconnect")
@@ -526,6 +528,8 @@ if __name__ == "__main__":
     IS_DEBUG = os.environ.get('DEBUG', '').lower() == 'true'
     if not IS_DEBUG:
         run_once(data_dir)
+
+    _start_connection_watcher()
 
     socketio.run(
         app,

--- a/server/tests/test_connect_and_diagnostics.py
+++ b/server/tests/test_connect_and_diagnostics.py
@@ -58,3 +58,48 @@ class ConnectDiagnosticsTestCase(unittest.TestCase):
         response = json.loads(response.data.decode())
         self.assertTrue(response['is_connected'])
         self.assertEquals(response['port'], 'Virtual Smoothie')
+
+    def test_diagnostics(self):
+        self.robot.disconnect()
+        self.robot.connect()
+
+        response = self.app.get(
+            '/robot/diagnostics',
+            content_type='application/json')
+        response = json.loads(response.data.decode())
+        expected = {
+            'axis_homed': {
+                'x': False, 'y': False, 'z': False, 'a': False, 'b': False
+            },
+            'switches': {
+                'x': False, 'y': False, 'z': False, 'a': False, 'b': False
+            },
+            'steps_per_mm': {
+                'x': 80.0, 'y': 80.0
+            }
+        }
+        self.assertEqual(response['diagnostics'], expected)
+
+    def test_versions(self):
+        self.robot.disconnect()
+        self.robot.connect()
+
+        response = self.app.get(
+            '/robot/versions',
+            content_type='application/json')
+        response = json.loads(response.data.decode())
+        expected = {
+            'firmware': {
+                'version': 'v1.0.5',
+                'compatible': True
+            },
+            'config': {
+                'version': 'v1.0.3b',
+                'compatible': True
+            },
+            'ot_version': {
+                'version': 'one_pro',
+                'compatible': True
+            }
+        }
+        self.assertEqual(response['versions'], expected)

--- a/server/tests/test_connect_and_diagnostics.py
+++ b/server/tests/test_connect_and_diagnostics.py
@@ -1,0 +1,60 @@
+import unittest
+import json
+import os
+
+from opentrons.robot import Robot
+
+
+class ConnectDiagnosticsTestCase(unittest.TestCase):
+    def setUp(self):
+        from main import app
+        self.app = app.test_client()
+
+        self.data_path = os.path.join(
+            os.path.dirname(__file__) + '/data/'
+        )
+
+        self.robot = Robot.get_instance()
+        self.robot.connect()
+
+    def upload_protocol(self):
+        response = self.app.post('/upload', data={
+            'file': (open(self.data_path + 'protocol.py', 'rb'), 'protocol.py')
+        })
+        status = json.loads(response.data.decode())['status']
+        self.assertEqual(status, 'success')
+
+    def test_connect(self):
+        data = {
+            'port': None,
+            'options': {
+                'firmware': 'v1.0.6'
+            }
+        }
+        response = self.app.post(
+            '/robot/serial/connect',
+            data=json.dumps(dict(data)),
+            content_type='application/json')
+
+        response = json.loads(response.data.decode())
+        self.assertEqual(response['status'], 'error')
+
+        response = self.app.get(
+            '/robot/serial/is_connected',
+            content_type='application/json')
+        response = json.loads(response.data.decode())
+        self.assertFalse(response['is_connected'])
+
+        response = self.app.post(
+            '/robot/serial/connect',
+            data=json.dumps(dict({})),
+            content_type='application/json')
+        response = json.loads(response.data.decode())
+        self.assertEqual(response['status'], 'success')
+
+        response = self.app.get(
+            '/robot/serial/is_connected',
+            content_type='application/json')
+        response = json.loads(response.data.decode())
+        self.assertTrue(response['is_connected'])
+        self.assertEquals(response['port'], 'Virtual Smoothie')

--- a/server/tests/test_upload.py
+++ b/server/tests/test_upload.py
@@ -42,6 +42,7 @@ class UploadTestCase(unittest.TestCase):
         self.assertEqual(status, 'success')
 
     def test_get_instrument_placeables(self):
+        self.robot.connect(None, options={'limit_switches': False})
         response = self.app.post('/upload', data={
             'file': (open(self.data_path + 'protocol.py', 'rb'), 'protocol.py')
         })


### PR DESCRIPTION
This PR:

1. Adds routes for getting robot diagnostics, and robot versions (includes firmware, config, and ot_version)
2. Detects version exception when `robot.connect()` is called. The API automatically raises an exception if the version aren't compatible, and the UI will receive this error (which includes the connected robot's versions)
3. Moves the `CONNECTION_STATE_WATCHER` background thread to start once when the script begins (instead of only once `/connect` route is hit