### PR TITLE
94 m pipette calibration ui

### DIFF
--- a/app/renderer/src/assets/sass/main.scss
+++ b/app/renderer/src/assets/sass/main.scss
@@ -2,6 +2,7 @@
 @import "header";
 @import "steplist";
 @import "buttons";
+@import "modals";
 
 nav {
     display: flex;

--- a/app/renderer/src/assets/sass/modals.scss
+++ b/app/renderer/src/assets/sass/modals.scss
@@ -1,0 +1,64 @@
+@import "util";
+
+.calibration-modal {
+    &.top {
+        .btn-update.top {
+            opacity: 1;
+            cursor: pointer;
+            pointer-events: all;
+        }
+        img.top{
+            display:block;
+        }
+    }
+    &.bottom {
+        .btn-update.bottom {
+            opacity: 1;
+            cursor: pointer;
+            pointer-events: all;
+        }
+        img.bottom{
+            display:block;
+        }
+    }
+    &.blowout {
+        .btn-update.blowout{
+            opacity: 1;
+            cursor: pointer;
+            pointer-events: all;
+        }
+        img.blowout{
+            display:block;
+        }
+    }
+    &.droptip {
+        .btn-update.droptip{
+            opacity: 1;
+            cursor: pointer;
+            pointer-events: all;
+        }
+        img.droptip{
+            display:block;
+        }
+    }
+
+    .btn-update {
+        opacity: 0.1;
+        pointer-events: none;
+        &.test{
+            opacity: 1;
+            cursor: pointer;
+            pointer-events: all;
+        }
+    }
+
+    .pipette-img{
+        img{
+            display:none;
+        }
+    }
+
+    a.position{
+        text-decoration: underline;
+    }
+}

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -1,33 +1,30 @@
 <template>
-
-<div class="calibration-modal mode-droptip">
-	<div class="pipette-img">
-<!-- 	  <img src="../assets/img/pipette_top.png" class="top" />
-	  <img src="../assets/img/pipette_bottom.png" class="bottom" />
-	  <img src="../assets/img/pipette_blowout.png" class="blowout" /> -->
-	  <img src="../assets/img/pipette_droptip.png" class="droptip" />
+	<div class="calibration-modal mode-droptip">
+		<div class="pipette-img">
+	<!-- 	  <img src="../assets/img/pipette_top.png" class="top" />
+		  <img src="../assets/img/pipette_bottom.png" class="bottom" />
+		  <img src="../assets/img/pipette_blowout.png" class="blowout" /> -->
+		  <img src="../assets/img/pipette_droptip.png" class="droptip" />
+		</div>
+		<div class="update">
+		  <span class="position top">Top</span>
+		  <button class="btn-update save top" data-save-pipette="top">Save</button>
+		  <button class="btn-update moveto ">Move</button>
+		  <div class="spacer"></div>
+		  <span class="position bottom">Bottom</span>
+		  <button class="btn-update save bottom" data-save-pipette="bottom">Save</button>
+		  <button class="btn-update moveto ">Move</button>
+		  <span class="position blowout">Blowout</span>
+		  <button class="btn-update save blowout" data-save-pipette="blowout">Save</button>
+		  <button class="btn-update moveto">Move</button>
+		  <span class="position droptip">Drop Tip</span>
+		  <button class="btn-update save droptip" data-save-pipette="droptip">Save</button>
+		  <button class="btn-update moveto disabled">Move</button>
+		  <button class="btn-update test pick-liquid disabled">Pick Up</button>
+		  <button class="btn-update test eject-liquid disabled">Eject</button>
+		</div>
+		</div>
 	</div>
-	<div class="update">
-	  <span class="position top">Top</span>
-	  <button class="btn-update save top" data-save-pipette="top">Save</button>
-	  <button class="btn-update moveto ">Move</button>
-	  <div class="spacer"></div>
-	  <span class="position bottom">Bottom</span>
-	  <button class="btn-update save bottom" data-save-pipette="bottom">Save</button>
-	  <button class="btn-update moveto ">Move</button>
-	  <span class="position blowout">Blowout</span>
-	  <button class="btn-update save blowout" data-save-pipette="blowout">Save</button>
-	  <button class="btn-update moveto">Move</button>
-	  <span class="position droptip">Drop Tip</span>
-	  <button class="btn-update save droptip" data-save-pipette="droptip">Save</button>
-	  <button class="btn-update moveto disabled">Move</button>
-	  <button class="btn-update test pick-liquid disabled">Pick Up</button>
-	  <button class="btn-update test eject-liquid disabled">Eject</button>
-	</div>
-	</div>
-</div>
-<!-- End Calibration Modal -->
-	
 </template>
 
 <script>
@@ -44,11 +41,10 @@
     		let axis = instrument.axis
     		let position = instrumant.postion
     		this.$store.dispatch("calibrateInstrument", {axis: axis, position: position})
-    	}			
+    	}
     },
-    computed: { 
-    	
-    }
+    computed: {
 
+    }
   }
 </script>

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -9,17 +9,17 @@
 		<div class="update">
 		  <span class="position top">Top</span>
 		  <button class="btn-update save top" @click="calibrateInstrument(instrument, 'top')">Save</button>
-		  <button class="btn-update moveto " @click="moveToPlungerPosition(instrument, 'top')">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'top')" :class="[{'disabled': disabled(instrument, 'top')}, 'btn-update', 'moveto']">Move</button>
 		  <div class="spacer"></div>
 		  <span class="position bottom">Bottom</span>
 		  <button class="btn-update save bottom" @click="calibrateInstrument(instrument, 'bottom')">Save</button>
-		  <button class="btn-update moveto " @click="moveToPlungerPosition(instrument, 'bottom')">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'bottom')" :class="[{'disabled': disabled(instrument, 'bottom')}, 'btn-update', 'moveto']">Move</button>
 		  <span class="position blowout">Blowout</span>
 		  <button class="btn-update save blowout" @click="calibrateInstrument(instrument, 'blow_out')">Save</button>
-		  <button class="btn-update moveto" @click="moveToPlungerPosition(instrument, 'blow_out')">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'blow_out')" :class="[{'disabled': disabled(instrument, 'blow_out')}, 'btn-update', 'moveto']">Move</button>
 		  <span class="position droptip">Drop Tip</span>
 		  <button class="btn-update save droptip" @click="calibrateInstrument(instrument, 'drop_tip')">Save</button>
-		  <button class="btn-update moveto " @click="moveToPlungerPosition(instrument, 'drop_tip')">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'drop_tip')" :class="[{'disabled': disabled(instrument, 'drop_tip')}, 'btn-update', 'moveto']">Move</button>
 		  <button class="btn-update test pick-liquid">Pick Up</button>
 		  <button class="btn-update test eject-liquid">Eject</button>
 		</div>
@@ -30,19 +30,22 @@
   export default {
     name: 'CalibrateInstrument',
     props: ['instrument'],
-    data: function() {
-      return {}
-    },
     methods: {
-    	calibrateInstrument(instrument, position){
+    	calibrateInstrument(instrument, position) {
     		let axis = instrument.axis
     		this.$store.dispatch("calibrateInstrument", {axis: axis, position: position})
     	},
-      moveToPlungerPosition(instrument, position){
+      moveToPlungerPosition(instrument, position) {
+				// TODO - disable this if the class disabled is on the given position
         let axis = instrument.axis
         this.$store.dispatch("moveToPlungerPosition", {axis: axis, position: position})
-      }
-    },
-    computed: {}
+      },
+			disabled(instrument, position) {
+				console.log("***********", instrument[position])
+				if (instrument[position] == undefined) {
+					return true
+				}
+			}
+    }
   }
 </script>

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -1,25 +1,25 @@
 <template>
-	<div class="calibration-modal mode-droptip">
+	<div class="calibration-modal" v-bind:class="currentMode">
 		<div class="pipette-img">
-	<!-- 	  <img src="../assets/img/pipette_top.png" class="top" />
+		  <img src="../assets/img/pipette_top.png" class="top" />
 		  <img src="../assets/img/pipette_bottom.png" class="bottom" />
-		  <img src="../assets/img/pipette_blowout.png" class="blowout" /> -->
+		  <img src="../assets/img/pipette_blowout.png" class="blowout" />
 		  <img src="../assets/img/pipette_droptip.png" class="droptip" />
 		</div>
 		<div class="update">
-		  <span class="position top">Top</span>
+		  <a @click="toggleMode('top')"class="position top">Top</a>
 		  <button class="btn-update save top" @click="calibrateInstrument(instrument, 'top')">Save</button>
-		  <button @click="moveToPlungerPosition(instrument, 'top')" :class="[{'disabled': disabled(instrument, 'top')}, 'btn-update', 'moveto']">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'top')" :class="[{'disabled': disabled(instrument, 'top')}, 'btn-update', 'moveto', 'top']">Move</button>
 		  <div class="spacer"></div>
-		  <span class="position bottom">Bottom</span>
+		  <a @click="toggleMode('bottom')" class="position bottom">Bottom</a>
 		  <button class="btn-update save bottom" @click="calibrateInstrument(instrument, 'bottom')">Save</button>
-		  <button @click="moveToPlungerPosition(instrument, 'bottom')" :class="[{'disabled': disabled(instrument, 'bottom')}, 'btn-update', 'moveto']">Move</button>
-		  <span class="position blowout">Blowout</span>
+		  <button @click="moveToPlungerPosition(instrument, 'bottom')" :class="[{'disabled': disabled(instrument, 'bottom')}, 'btn-update', 'moveto', 'bottom']">Move</button>
+		  <a @click="toggleMode('blowout')" class="position blowout">Blowout</a>
 		  <button class="btn-update save blowout" @click="calibrateInstrument(instrument, 'blow_out')">Save</button>
-		  <button @click="moveToPlungerPosition(instrument, 'blow_out')" :class="[{'disabled': disabled(instrument, 'blow_out')}, 'btn-update', 'moveto']">Move</button>
-		  <span class="position droptip">Drop Tip</span>
+		  <button @click="moveToPlungerPosition(instrument, 'blow_out')" :class="[{'disabled': disabled(instrument, 'blow_out')}, 'btn-update', 'moveto', 'blowout']">Move</button>
+		  <a @click="toggleMode('droptip')" class="position droptip">Drop Tip</a>
 		  <button class="btn-update save droptip" @click="calibrateInstrument(instrument, 'drop_tip')">Save</button>
-		  <button @click="moveToPlungerPosition(instrument, 'drop_tip')" :class="[{'disabled': disabled(instrument, 'drop_tip')}, 'btn-update', 'moveto']">Move</button>
+		  <button @click="moveToPlungerPosition(instrument, 'drop_tip')" :class="[{'disabled': disabled(instrument, 'drop_tip')}, 'btn-update', 'moveto', 'droptip']">Move</button>
 		  <button class="btn-update test pick-liquid">Pick Up</button>
 		  <button class="btn-update test eject-liquid">Eject</button>
 		</div>
@@ -30,6 +30,11 @@
   export default {
     name: 'CalibrateInstrument',
     props: ['instrument'],
+    data: function () {
+      return {
+        currentMode : 'droptip'
+      }
+    },
     methods: {
     	calibrateInstrument(instrument, position) {
     		let axis = instrument.axis
@@ -45,7 +50,10 @@
 				if (instrument[position] == undefined) {
 					return true
 				}
-			}
+			},
+      toggleMode(mode){
+        this.currentMode =  mode;
+      }
     }
   }
 </script>

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -36,7 +36,7 @@
     		this.$store.dispatch("calibrateInstrument", {axis: axis, position: position})
     	},
       moveToPlungerPosition(instrument, position) {
-				// TODO - disable this if the class disabled is on the given position
+				// TODO - test if this moves the robot if the class disabled is on the given position
         let axis = instrument.axis
         this.$store.dispatch("moveToPlungerPosition", {axis: axis, position: position})
       },

--- a/app/renderer/src/components/Home.vue
+++ b/app/renderer/src/components/Home.vue
@@ -4,7 +4,7 @@
       <header class="brand">
         <nav class="links">
           <ul>
-            <li>OT App</li>
+            <li>Logo</li>
           </ul>
         </nav>
       </header>

--- a/app/renderer/src/components/Instrument.vue
+++ b/app/renderer/src/components/Instrument.vue
@@ -1,19 +1,19 @@
 <template>
   <div>
-    <h2 class="title">Calibrate {{ calibration.label }} pipette</h2>
+    <h2 class="title">Calibrate {{ instrument.label }} pipette</h2>
     <div class="instructions">
-      Calibrate {{ calibration.label }}'s plunger. Be sure to save top, bottom, blowout, and droptip. Enter max volume.
+      Calibrate {{ instrument.label }}'s plunger. Be sure to save top, bottom, blowout, and droptip. Enter max volume.
     </div>
 
     <section>
       <div class="step step-calibrate">
-        <Jog :instrument="calibration.axis"></Jog>
-        <JogPlunger :axis="calibration.axis"></JogPlunger>
+        <Jog :instrument="instrument.axis"></Jog>
+        <JogPlunger :axis="instrument.axis"></JogPlunger>
         <div class="save-pipette">
             <h3 class="title">Current Position</h3>
-            <coordinates :instrument="calibration" :axis="calibration.axis.toUpperCase()"></coordinates>
-            <h3 class="title">Calibrate {{ calibration.label }} axis {{calibration.axis.toUpperCase() }}</h3>
-            <CalibrateInstrument :instrument="calibration"></CalibrateInstrument>
+            <coordinates :instrument="instrument" :axis="instrument.axis.toUpperCase()"></coordinates>
+            <h3 class="title">Calibrate {{ instrument.label }} axis {{instrument.axis.toUpperCase() }}</h3>
+            <CalibrateInstrument :instrument="instrument"></CalibrateInstrument>
         </div>
       </div>
       <Navigation :prev="prev" :next="next"></Navigation>
@@ -48,7 +48,7 @@
       }
     },
     computed: {
-      calibration() {
+      instrument() {
         let tasks = this.$store.state.tasks
         let instrument = this.currentInstrument(tasks)
         return instrument

--- a/app/renderer/src/components/StepList.vue
+++ b/app/renderer/src/components/StepList.vue
@@ -18,7 +18,7 @@
       <ul>
       <li>
         <router-link v-bind:to="instrument.href" :class="{'completed': instrument.calibrated}" exact>
-          Calibrate {{instrument.label}}
+          calibrate {{instrument.label}}
         </router-link>
       </li>
       </ul>

--- a/app/renderer/src/store/mutations.js
+++ b/app/renderer/src/store/mutations.js
@@ -13,7 +13,6 @@ const state = {
   coordinates: {"x":0, "y":0, "z":0, "a":0, "b":0}
 }
 
-
 const mutations = {
   [types.UPDATE_ROBOT_CONNECTION] (state, payload) {
     state.is_connected = payload.is_connected

--- a/server/main.py
+++ b/server/main.py
@@ -129,7 +129,6 @@ def _run_commands():
 
 @app.route("/run", methods=["GET"])
 def run():
-
     api_response = _run_commands()
 
     return flask.jsonify({
@@ -143,7 +142,6 @@ def run():
 
 @app.route("/pause", methods=["GET"])
 def pause():
-
     robot.pause()
 
     return flask.jsonify({
@@ -154,7 +152,6 @@ def pause():
 
 @app.route("/resume", methods=["GET"])
 def resume():
-
     robot.resume()
 
     return flask.jsonify({
@@ -165,7 +162,6 @@ def resume():
 
 @app.route("/stop", methods=["GET"])
 def stop():
-
     robot.stop()
 
     return flask.jsonify({
@@ -297,6 +293,12 @@ def get_step_list():
                 return True
         return False
 
+    def check_if_instrument_calibrated(instrument):
+        pos = instrument.positions
+        if pos["top"] and pos["bottom"] and pos["blow_out"] and pos["drop_tip"]:
+            return True
+        return False
+
     data = [{
         'axis': instrument.axis,
         'label': instrument.name,
@@ -305,6 +307,7 @@ def get_step_list():
         'blow_out': instrument.positions['blow_out'],
         'drop_tip': instrument.positions['drop_tip'],
         'max_volume': instrument.max_volume,
+        'calibrated': check_if_instrument_calibrated(instrument),
         'placeables': [
             {
                 'type': placeable.properties['type'],

--- a/server/main.py
+++ b/server/main.py
@@ -294,10 +294,13 @@ def get_step_list():
         return False
 
     def check_if_instrument_calibrated(instrument):
-        pos = instrument.positions
-        if pos["top"] and pos["bottom"] and pos["blow_out"] and pos["drop_tip"]:
-            return True
-        return False
+        positions = instrument.positions
+        for p in positions:
+            if positions.get(p) is None:
+                return False
+
+        return True
+
 
     data = [{
         'axis': instrument.axis,

--- a/server/tests/data/protocol.py
+++ b/server/tests/data/protocol.py
@@ -5,25 +5,25 @@ from opentrons import instruments
 plate = containers.load(
     '96-flat',
     'B2',
-    'plate-for-frontend-test'
+    'test-plate'
 )
 
 tiprack = containers.load(
     'tiprack-200ul',  # container type from library
     'A1',             # slot on deck
-    'tiprack-for-frontend-test'
+    'test-tiprack'
 )
 
 trough = containers.load(
     'trough-12row',
     'B1',
-    'trough-for-frontend-test'
+    'test-trough'
 )
 
 trash = containers.load(
     'point',
     'A2',
-    'trash-for-frontend-test'
+    'test-trash'
 )
 
 p200 = instruments.Pipette(

--- a/server/tests/data/protocol.py
+++ b/server/tests/data/protocol.py
@@ -1,6 +1,5 @@
 from opentrons import containers
 from opentrons import instruments
-#  from opentrons.robot import Robot
 
 plate = containers.load(
     '96-flat',
@@ -26,8 +25,8 @@ trash = containers.load(
     'test-trash'
 )
 
-p200 = instruments.Pipette(
-    name="p200",
+p1000 = instruments.Pipette(
+    name="p1000",
     trash_container=trash,
     tip_racks=[tiprack],
     min_volume=10,  # These are variable
@@ -42,17 +41,21 @@ p10 = instruments.Pipette(
     axis="a",
     channels=1
 )
-p200.set_max_volume(200)
-p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
+
+p1000.calibration_data = {}
+for key in p1000.positions.keys():
+    p1000.positions[key] = None
+p1000.update_calibrations()
+p1000.set_max_volume(200)
+
 p10.set_max_volume(10)
-p10.calibrate_plunger(top=0, bottom=11, blow_out=13, drop_tip=14)
 
-p200.pick_up_tip(tiprack[0])
+p1000.pick_up_tip(tiprack[0])
 
-p200.aspirate(10, trough[0])
-p200.dispense(10, plate[0])
+p1000.aspirate(10, trough[0])
+p1000.dispense(10, plate[0])
 
-p200.drop_tip(trash)
+p1000.drop_tip(trash)
 
 p10.pick_up_tip(tiprack[0])
 

--- a/server/tests/test_calibration.py
+++ b/server/tests/test_calibration.py
@@ -56,7 +56,7 @@ class CalibrationTestCase(unittest.TestCase):
         self.robot.move_to = mock.Mock()
 
         arguments = {
-            'label': 'plate-for-frontend-test',
+            'label': 'test-plate',
             'slot': 'B2',
             'axis': 'b'
         }
@@ -70,7 +70,7 @@ class CalibrationTestCase(unittest.TestCase):
         self.assertEqual(status, 'success')
 
         container = self.robot._deck['B2'].get_child_by_name(
-            'plate-for-frontend-test')
+            'test-plate')
         instrument = self.robot._instruments['B']
         expected = [
             mock.call(
@@ -90,7 +90,7 @@ class CalibrationTestCase(unittest.TestCase):
         self.assertEqual(status, 'success')
 
         arguments = {
-            'label': 'plate-for-frontend-test',
+            'label': 'test-plate',
             'axis': 'b'
         }
 
@@ -105,7 +105,7 @@ class CalibrationTestCase(unittest.TestCase):
         step_list = actual['data']['calibrations']
         status = actual['status']
 
-        self.assertEqual(name, 'plate-for-frontend-test')
+        self.assertEqual(name, 'test-plate')
         self.assertEqual(axis, 'b')
         self.assertTrue(bool(step_list))
         self.assertEqual(status, 'success')

--- a/server/tests/test_upload.py
+++ b/server/tests/test_upload.py
@@ -68,7 +68,7 @@ class UploadTestCase(unittest.TestCase):
             instrument.update_calibrations()
 
         location = robot._deck['A1'].get_child_by_name(
-            'tiprack-for-frontend-test')
+            'test-tiprack')
         rel_vector = location[0].from_center(
             x=0, y=0, z=-1, reference=location)
         location = (location, rel_vector)
@@ -92,25 +92,25 @@ class UploadTestCase(unittest.TestCase):
                     'placeables': [
                         {
                             'calibrated': True,
-                            'label': 'tiprack-for-frontend-test',
+                            'label': 'test-tiprack',
                             'slot': 'A1',
                             'type': 'tiprack-200ul'
                         },
                         {
                             'calibrated': False,
-                            'label': 'trough-for-frontend-test',
+                            'label': 'test-trough',
                             'slot': 'B1',
                             'type': 'trough-12row'
                         },
                         {
                             'calibrated': False,
-                            'label': 'plate-for-frontend-test',
+                            'label': 'test-plate',
                             'slot': 'B2',
                             'type': '96-flat'
                         },
                         {
                             'calibrated': False,
-                            'label': 'trash-for-frontend-test',
+                            'label': 'test-trash',
                             'slot': 'A2',
                             'type': 'point'
                         }
@@ -127,25 +127,25 @@ class UploadTestCase(unittest.TestCase):
                     'placeables': [
                         {
                             'calibrated': False,
-                            'label': 'tiprack-for-frontend-test',
+                            'label': 'test-tiprack',
                             'slot': 'A1',
                             'type': 'tiprack-200ul'
                         },
                         {
                             'calibrated': False,
-                            'label': 'trough-for-frontend-test',
+                            'label': 'test-trough',
                             'slot': 'B1',
                             'type': 'trough-12row'
                         },
                         {
                             'calibrated': False,
-                            'label': 'plate-for-frontend-test',
+                            'label': 'test-plate',
                             'slot': 'B2',
                             'type': '96-flat'
                         },
                         {
                             'calibrated': False,
-                            'label': 'trash-for-frontend-test',
+                            'label': 'test-trash',
                             'slot': 'A2',
                             'type': 'point'
                         }


### PR DESCRIPTION
This PR by Katie and I:
    * saves plunger positions
    * moves to plunger positions
    * disables move to plunger positions when not calibrated
    * adds a checkmark next to calibrated instruments

For reference, I also made a small change to `protocol.py` to delete all calibration data for one of the pipette's. This is so you can calibrate a pipette yourself, as otherwise the backend will return cached calibration data and you will never be able to see the pipette calibration process.