### PR TITLE
Frontend refactors

### DIFF
--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -30,7 +30,7 @@
   export default {
     name: 'CalibrateInstrument',
     props: ['instrument'],
-    data: function () {
+    data: function() {
       return {
         currentMode : 'droptip'
       }
@@ -38,13 +38,12 @@
     methods: {
     	calibrateInstrument(instrument, position) {
     		let axis = instrument.axis
-    		this.$store.dispatch("calibrate", {axis: axis, position: position})
+    		this.$store.dispatch("calibrate", {axis, position})
     	},
       moveToPlungerPosition(instrument, position) {
 				// TODO - test if this moves the robot if the class disabled is on the given position
         let axis = instrument.axis
-				// TODO use es6 objects here - {axis, position}
-        this.$store.dispatch("moveToPlungerPosition", {axis: axis, position: position})
+        this.$store.dispatch("moveToPlungerPosition", {axis, position})
       },
 			disabled(instrument, position) {
 				if (instrument[position] == undefined) { return true }

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -43,7 +43,7 @@
       moveToPlungerPosition(instrument, position) {
 				// TODO - test if this moves the robot if the class disabled is on the given position
         let axis = instrument.axis
-        this.$store.dispatch("moveToPlungerPosition", {axis, position})
+        this.$store.dispatch("moveToPosition", {axis, position})
       },
 			disabled(instrument, position) {
 				if (instrument[position] == undefined) { return true }

--- a/app/renderer/src/components/CalibrateInstrument.vue
+++ b/app/renderer/src/components/CalibrateInstrument.vue
@@ -38,21 +38,19 @@
     methods: {
     	calibrateInstrument(instrument, position) {
     		let axis = instrument.axis
-    		this.$store.dispatch("calibrateInstrument", {axis: axis, position: position})
+    		this.$store.dispatch("calibrate", {axis: axis, position: position})
     	},
       moveToPlungerPosition(instrument, position) {
 				// TODO - test if this moves the robot if the class disabled is on the given position
         let axis = instrument.axis
+				// TODO use es6 objects here - {axis, position}
         this.$store.dispatch("moveToPlungerPosition", {axis: axis, position: position})
       },
 			disabled(instrument, position) {
-				console.log("***********", instrument[position])
-				if (instrument[position] == undefined) {
-					return true
-				}
+				if (instrument[position] == undefined) { return true }
 			},
       toggleMode(mode){
-        this.currentMode =  mode;
+        this.currentMode = mode
       }
     }
   }

--- a/app/renderer/src/components/CalibratePlaceable.vue
+++ b/app/renderer/src/components/CalibratePlaceable.vue
@@ -3,7 +3,7 @@
 <div class="calibration-modal">
 	<!-- Show Images based on container type. -->
 	<div class="well-img">
-		<img src="../assets/img/well_bottom.png" v-show="placeableType('default')" /> 
+		<img src="../assets/img/well_bottom.png" v-show="placeableType('default')" />
 		<img src="../assets/img/tiprack_top.png" v-show="placeableType('tiprack')"/>
 		<img src="../assets/img/point_top.png" v-show="placeableType('point')"/>
 	</div>
@@ -25,7 +25,7 @@
 
 </div>
 <!-- End Calibration Modal -->
-	
+
 </template>
 
 <script>
@@ -40,7 +40,7 @@
 				let slot = placeable.slot
 				let label = placeable.label
 				let axis = instrument.axis
-				this.$store.dispatch("calibratePlaceable", {slot: slot, label: label, axis: axis})
+				this.$store.dispatch("calibrate", {slot: slot, label: label, axis: axis})
 			},
 			moveToPlaceable(placeable,instrument){
         let slot = placeable.slot
@@ -49,7 +49,7 @@
         this.$store.dispatch("moveToPlaceable", {slot: slot, label: label, axis: axis})
       }
     },
-    computed: { 
+    computed: {
     	currentType(){
     		return placeableType(this.type);
     	}

--- a/app/renderer/src/components/CalibratePlaceable.vue
+++ b/app/renderer/src/components/CalibratePlaceable.vue
@@ -41,14 +41,6 @@
         let axis = instrument.axis
         this.$store.dispatch("moveToPosition", {slot: slot, label: label, axis: axis})
       }
-<<<<<<< HEAD
-    },
-    computed: {
-    	currentType(){
-    		return placeableType(this.type);
-    	}
-=======
->>>>>>> master
     }
   }
 </script>

--- a/app/renderer/src/components/CalibratePlaceable.vue
+++ b/app/renderer/src/components/CalibratePlaceable.vue
@@ -26,16 +26,16 @@
     name: 'CalibratePlaceable',
     props: ['instrument', 'placeable', 'type'],
     methods: {
-			placeableType(type){
+			placeableType(type) {
 				return this.type === type
 			},
-			calibratePlaceable(placeable, instrument){
+			calibratePlaceable(placeable, instrument) {
 				let slot = placeable.slot
 				let label = placeable.label
 				let axis = instrument.axis
 				this.$store.dispatch("calibrate", {slot: slot, label: label, axis: axis})
 			},
-			moveToPlaceable(placeable,instrument){
+			moveToPlaceable(placeable,instrument) {
         let slot = placeable.slot
         let label = placeable.label
         let axis = instrument.axis

--- a/app/renderer/src/components/CalibratePlaceable.vue
+++ b/app/renderer/src/components/CalibratePlaceable.vue
@@ -1,31 +1,25 @@
 <template>
+	<div class="calibration-modal">
+		<div class="well-img">
+			<img src="../assets/img/well_bottom.png" v-show="placeableType('default')" />
+			<img src="../assets/img/tiprack_top.png" v-show="placeableType('tiprack')"/>
+			<img src="../assets/img/point_top.png" v-show="placeableType('point')"/>
+		</div>
 
-<div class="calibration-modal">
-	<!-- Show Images based on container type. -->
-	<div class="well-img">
-		<img src="../assets/img/well_bottom.png" v-show="placeableType('default')" />
-		<img src="../assets/img/tiprack_top.png" v-show="placeableType('tiprack')"/>
-		<img src="../assets/img/point_top.png" v-show="placeableType('point')"/>
+		<div class="update bottom" v-show="placeableType('default') || placeableType('point')">
+			<span class="position bottom">Bottom</span>
+			<button class="btn-update save bottom" @click="calibratePlaceable(placeable,instrument)" >Save </button>
+			<button class="btn-update moveto" :class="{'disabled': !placeable.calibrated}" @click="moveToPlaceable(placeable,instrument)">Move To </button>
+		</div>
+
+		<div class="update top" v-show="placeableType('tiprack')">
+			<span class="position top">Tiprack</span>
+			<button class="btn-update save top" @click="calibratePlaceable(placeable,instrument)">Save </button>
+			<button class="btn-update moveto" :class="{'disabled': !placeable.calibrated}" @click="moveToPlaceable(placeable,instrument)">Move To </button>
+			<button class="pick-tip" :class="{'disabled': !placeable.calibrated}">Pick Up Tip</button>
+		</div>
+
 	</div>
-
-	<!-- Calibrate to bottom if point or default well -->
-	<div class="update bottom" v-show="placeableType('default') || placeableType('point')">
-		<span class="position bottom">Bottom</span>
-		<button class="btn-update save bottom" @click="calibratePlaceable(placeable,instrument)" >Save </button>
-		<button class="btn-update moveto" :class="{'disabled': !placeable.calibrated}" @click="moveToPlaceable(placeable,instrument)">Move To </button>
-	</div>
-
-	<!-- Calibrate to top for tiprack, toggle pick up tip button -->
-	<div class="update top" v-show="placeableType('tiprack')">
-		<span class="position top">Tiprack</span>
-		<button class="btn-update save top" @click="calibratePlaceable(placeable,instrument)">Save </button>
-		<button class="btn-update moveto" :class="{'disabled': !placeable.calibrated}" @click="moveToPlaceable(placeable,instrument)">Move To </button>
-		<button class="pick-tip" :class="{'disabled': !placeable.calibrated}">Pick Up Tip</button>
-	</div>
-
-</div>
-<!-- End Calibration Modal -->
-
 </template>
 
 <script>
@@ -46,7 +40,7 @@
         let slot = placeable.slot
         let label = placeable.label
         let axis = instrument.axis
-        this.$store.dispatch("moveToPlaceable", {slot: slot, label: label, axis: axis})
+        this.$store.dispatch("moveToPosition", {slot: slot, label: label, axis: axis})
       }
     },
     computed: {

--- a/app/renderer/src/rest_api_wrapper.js
+++ b/app/renderer/src/rest_api_wrapper.js
@@ -8,6 +8,8 @@ class OpenTrons {
     this.disconnectUrl = this.base_url + '/robot/serial/disconnect'
     this.jogUrl = this.base_url + '/jog'
     this.jogToSlotUrl = this.base_url + '/move_to_slot'
+    this.jogToContainerUrl = this.base_url + '/move_to_container'
+    this.jogToPlungerUrl = this.base_url + '/move_to_plunger_position'
   }
 
   connect (port) {
@@ -38,6 +40,21 @@ class OpenTrons {
         }
       }, (response) => {
         console.log('Failed to communicate to server', response)
+      })
+  }
+
+  moveToPosition(data, type) {
+    let url = this.jogToContainerUrl
+    if type == "plunger" { url = this.jogToPlungerUrl }
+
+    return Vue.http
+      .post(url, JSON.stringify(data), {emulateJSON: true})
+      .then((response) => {
+        console.log("success", response)
+        return true
+      }, (response) => {
+        console.log('failed', response)
+        return false
       })
   }
 

--- a/app/renderer/src/rest_api_wrapper.js
+++ b/app/renderer/src/rest_api_wrapper.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import {addHrefs} from './util'
 
 
 class OpenTrons {
@@ -45,7 +46,7 @@ class OpenTrons {
 
   moveToPosition(data, type) {
     let url = this.jogToContainerUrl
-    if type == "plunger" { url = this.jogToPlungerUrl }
+    if (type == "plunger") { url = this.jogToPlungerUrl }
 
     return Vue.http
       .post(url, JSON.stringify(data), {emulateJSON: true})
@@ -99,15 +100,16 @@ class OpenTrons {
   }
 
   calibrate(data, type) {
-    Vue.http
-    .post(`${this.base_url}/calibrate_${type}`, JSON.stringify(data), {emulateJSON: true})
-    .then((response) => {
-      let tasks = response.body.data.calibrations
-      addHrefs(tasks)
-      commit('UPDATE_TASK_LIST', {'tasks': tasks})
-    }, (response) => {
-       console.log('failed', response)
-    })
+    return Vue.http
+      .post(`${this.base_url}/calibrate_${type}`, JSON.stringify(data), {emulateJSON: true})
+      .then((response) => {
+        let tasks = response.body.data.calibrations
+        addHrefs(tasks)
+        return tasks
+      }, (response) => {
+         console.log('failed', response)
+         return false
+      })
   }
 }
 

--- a/app/renderer/src/rest_api_wrapper.js
+++ b/app/renderer/src/rest_api_wrapper.js
@@ -15,7 +15,6 @@ class OpenTrons {
     return Vue.http
       .post(this.connectUrl, options)
       .then((response) => {
-        console.log(response.data)
         if (response.data.status === "success") {
           console.log('successfully connected...')
           return true
@@ -63,6 +62,7 @@ class OpenTrons {
         console.log('failed', response)
       })
   }
+
   uploadProtocol (formData) {
     return Vue.http
       .post('http://localhost:5000/upload', formData)
@@ -79,6 +79,18 @@ class OpenTrons {
       }, (response) => {
         console.log('Failed to upload protocol', response)
       })
+  }
+
+  calibrate(data, type) {
+    Vue.http
+    .post(`http://localhost:5000/calibrate_${type}`, JSON.stringify(data), {emulateJSON: true})
+    .then((response) => {
+      let tasks = response.body.data.calibrations
+      addHrefs(tasks)
+      commit('UPDATE_TASK_LIST', {'tasks': tasks})
+    }, (response) => {
+       console.log('failed', response)
+    })
   }
 }
 

--- a/app/renderer/src/rest_api_wrapper.js
+++ b/app/renderer/src/rest_api_wrapper.js
@@ -83,7 +83,7 @@ class OpenTrons {
 
   calibrate(data, type) {
     Vue.http
-    .post(`http://localhost:5000/calibrate_${type}`, JSON.stringify(data), {emulateJSON: true})
+    .post(`${this.base_url}/calibrate_${type}`, JSON.stringify(data), {emulateJSON: true})
     .then((response) => {
       let tasks = response.body.data.calibrations
       addHrefs(tasks)

--- a/app/renderer/src/store/actions.js
+++ b/app/renderer/src/store/actions.js
@@ -44,34 +44,16 @@ const actions = {
   jogToSlot ({commit}, data) {
     OpenTrons.jogToSlot(data)
   },
-  calibratePlaceable({commit}, data) {
-    Vue.http
-    .post('http://localhost:5000/calibrate_placeable', JSON.stringify(data), {emulateJSON: true})
-    .then((response) => {
-      let tasks = response.body.data.calibrations
-      addHrefs(tasks)
-      commit('UPDATE_TASK_LIST', {'tasks': tasks})
-    }, (response) => {
-       console.log('failed', response)
-    })
+  calibrate({commit}, data) {
+    let type = "instrument"
+    if (data.slot) { type = "placeable"}
+    OpenTrons.calibrate(data, type)
   },
   moveToPlaceable({commit}, data) {
     Vue.http
     .post('http://localhost:5000/move_to_container', JSON.stringify(data), {emulateJSON: true})
     .then((response) => {
        console.log('success',response)
-    }, (response) => {
-       console.log('failed', response)
-    })
-  },
-  calibrateInstrument({commit}, data) {
-    Vue.http
-    .post('http://localhost:5000/calibrate_plunger', JSON.stringify(data), {emulateJSON: true})
-    .then((response) => {
-      console.log('success',response.body.data)
-      let tasks = response.body.data.calibrations
-      addHrefs(tasks)
-      commit('UPDATE_TASK_LIST', {'tasks': tasks})
     }, (response) => {
        console.log('failed', response)
     })

--- a/app/renderer/src/store/actions.js
+++ b/app/renderer/src/store/actions.js
@@ -44,12 +44,16 @@ const actions = {
   jogToSlot ({commit}, data) {
     OpenTrons.jogToSlot(data)
   },
-  calibrate({commit}, data) {
-    let type = "instrument"
+  calibrate ({commit}, data) {
+    let type = "plunger"
     if (data.slot) { type = "placeable"}
-    OpenTrons.calibrate(data, type)
+    OpenTrons.calibrate(data, type).then((tasks) => {
+      if (tasks) {
+        commit('UPDATE_TASK_LIST', {'tasks': tasks})
+      }
+    })
   },
-  moveToPosition({commit} data) {
+  moveToPosition ({commit}, data) {
     let type = "plunger"
     if (data.slot) { type = "placeable" }
     OpenTrons.moveToPosition(data, type)

--- a/app/renderer/src/store/actions.js
+++ b/app/renderer/src/store/actions.js
@@ -49,25 +49,11 @@ const actions = {
     if (data.slot) { type = "placeable"}
     OpenTrons.calibrate(data, type)
   },
-  moveToPlaceable({commit}, data) {
-    Vue.http
-    .post('http://localhost:5000/move_to_container', JSON.stringify(data), {emulateJSON: true})
-    .then((response) => {
-       console.log('success',response)
-    }, (response) => {
-       console.log('failed', response)
-    })
-  },
-  moveToPlungerPosition({commit}, data){
-    Vue.http
-    .post('http://localhost:5000/move_to_plunger_position', JSON.stringify(data), {emulateJSON: true})
-    .then((response) => {
-       console.log('success',response)
-    }, (response) => {
-       console.log('failed', response)
-    })
+  moveToPosition({commit} data) {
+    let type = "plunger"
+    if (data.slot) { type = "placeable" }
+    OpenTrons.moveToPosition(data, type)
   }
-
 }
 
 export default {

--- a/app/renderer/src/store/actions.js
+++ b/app/renderer/src/store/actions.js
@@ -35,8 +35,8 @@ const actions = {
     })
   },
   selectIncrement ({commit}, data) {
-    commit(types.UPDATE_INCREMENT, {
-      'current_increment': data.inc, 'type': data.type })
+    let {inc, type} = data
+    commit(types.UPDATE_INCREMENT, { 'current_increment': inc, 'type': type })
   },
   jog ({commit}, coords) {
     OpenTrons.jog(coords)


### PR DESCRIPTION
This PR:
   * Refactors HTTP requests out of `actions` and into the `rest_api_wrapper` (for separation of concerns and to reduce reused code)
   * Makes a number of stylistic ES6 refactors
   * Fixes the placeable calibration screen to display save and move to properly 