### PR TITLE
add resolve url loader

### DIFF
--- a/app/renderer/src/assets/sass/main.scss
+++ b/app/renderer/src/assets/sass/main.scss
@@ -54,7 +54,7 @@ div.error {
     overflow-y:scroll;
     font-size: 16px;
     font-weight: 600;
-    
+
     height: 40px;
     div {
         display: flex;
@@ -112,9 +112,9 @@ Wizard Screens
         .step {
             display: flex;
             flex-wrap: wrap;
-            min-height: 440px;          
+            min-height: 440px;
         }
-        .step-connect {          
+        .step-connect {
             flex-direction: column;
             justify-content: center;
             align-items: center;

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "dependencies": {
     "babel-preset-es2016": "^6.16.0",
     "electron-debug": "^1.0.1",
+    "resolve-url-loader": "^1.6.0",
     "socket.io-client": "~1.3.7",
     "vue": "^2.0.1",
     "vue-resource": "^1.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
       },
       {
         test: /\.scss$/,
-        loaders: ["style", "css", "sass"]
+        loaders: ["style", "css", 'resolve-url', "sass?sourceMap"]
       },
       {
         test: /\.(woff|woff2)$/,


### PR DESCRIPTION
this PR fixes an error I got when running the unit tests that didn't allow karma to find the webpack bundled assets that were referenced by relative urls in sass.