### PR TITLE
get logger only after app is ready

### DIFF
--- a/app/main/logging.js
+++ b/app/main/logging.js
@@ -28,11 +28,14 @@ function createLogger(path, name) {
 }
 
 function getLogger(name) {
-  const loggerPath = path.join(
-    app.getPath('userData'),
-    'otone_data',
-    name.concat('.log')
-  )
+  const logDir = path.join(app.getPath('userData'), 'otone_data')
+  try {
+    fs.mkdirSync(logDir)
+  } catch (e) {
+    // file exists..
+  }
+
+  const loggerPath = path.join(logDir, name.concat('.log'))
   return createLogger(loggerPath, name)
 }
 

--- a/app/main/main.js
+++ b/app/main/main.js
@@ -8,7 +8,6 @@ const {initAutoUpdater} = require('./updater.js')
 
 
 let serverManager = new ServerManager()
-const mainLogger = getLogger('electron-main')
 let mainWindow
 
 function createWindow () {
@@ -23,6 +22,8 @@ function createWindow () {
 }
 
 function startUp() {
+  const mainLogger = getLogger('electron-main')
+
   serverManager.start();
   setTimeout(createWindow, 2000)
   initAutoUpdater()


### PR DESCRIPTION
This PR fixes the app not starting up when no previous install exists. This fixes a race condition that occurs when the app is trying to get an instance to the logger before the app reached it's `ready` state and created it's `userData` dir.