### PR TITLE
execute-do-while-adding-command-to-simulate

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -485,7 +485,7 @@ def move_to_plunger_position():
     axis = request.json.get("axis")
     try:
         instrument = robot._instruments[axis.upper()]
-        instrument.plunger.move(instrument.positions[position])
+        instrument.motor.move(instrument.positions[position])
     except Exception as e:
         return flask.jsonify({
             'status': 'error',

--- a/server/tests/test_calibration.py
+++ b/server/tests/test_calibration.py
@@ -27,9 +27,9 @@ class CalibrationTestCase(unittest.TestCase):
         status = json.loads(response.data.decode())['status']
         self.assertEqual(status, 'success')
 
-        self.robot._instruments['B'].plunger.move(12)
+        self.robot._instruments['B'].motor.move(12)
         self.robot._instruments['B'].calibrate('bottom')
-        self.robot._instruments['B'].plunger.move(2)
+        self.robot._instruments['B'].motor.move(2)
         current_pos = self.robot._driver.get_plunger_positions()['target']
         self.assertEquals(current_pos['b'], 2)
 
@@ -77,7 +77,7 @@ class CalibrationTestCase(unittest.TestCase):
                 container[0].bottom(),
                 instrument=instrument,
                 strategy='arc',
-                now=True)
+                enqueue=False)
         ]
         self.assertEquals(self.robot.move_to.mock_calls, expected)
 
@@ -117,7 +117,7 @@ class CalibrationTestCase(unittest.TestCase):
         status = json.loads(response.data.decode())['status']
         self.assertEqual(status, 'success')
 
-        self.robot._instruments['B'].plunger.move(2)
+        self.robot._instruments['B'].motor.move(2)
         arguments = {'position': 'top', 'axis': 'b'}
         response = self.app.post(
             '/calibrate_plunger',
@@ -129,7 +129,7 @@ class CalibrationTestCase(unittest.TestCase):
         saved_pos = self.robot._instruments['B'].positions['top']
         self.assertEquals(saved_pos, 2)
 
-        self.robot._instruments['B'].plunger.move(3)
+        self.robot._instruments['B'].motor.move(3)
         arguments = {'position': 'bottom', 'axis': 'b'}
         response = self.app.post(
             '/calibrate_plunger',
@@ -141,7 +141,7 @@ class CalibrationTestCase(unittest.TestCase):
         saved_pos = self.robot._instruments['B'].positions['bottom']
         self.assertEquals(saved_pos, 3)
 
-        self.robot._instruments['B'].plunger.move(4)
+        self.robot._instruments['B'].motor.move(4)
         arguments = {'position': 'blow_out', 'axis': 'b'}
         response = self.app.post(
             '/calibrate_plunger',
@@ -153,7 +153,7 @@ class CalibrationTestCase(unittest.TestCase):
         saved_pos = self.robot._instruments['B'].positions['blow_out']
         self.assertEquals(saved_pos, 4)
 
-        self.robot._instruments['B'].plunger.move(5)
+        self.robot._instruments['B'].motor.move(5)
         arguments = {'position': 'drop_tip', 'axis': 'b'}
         response = self.app.post(
             '/calibrate_plunger',


### PR DESCRIPTION
This PR goes along with a opentrons-api PR of the same name ("execute-do-while-adding-command-to-simulate")

1. This has replaced instances of `now=True` with `enqueue=False`
2. Flask server routes `/pick_up_tip` and `/drop_tip` use actually use `instrument.pick_up_tip()` and `instrument.drop_tip()`, since Instrument commands can skip the queue now

