### PR TITLE
Volume calibration routes

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -578,6 +578,68 @@ def move_to_plunger_position():
     })
 
 
+@app.route('/aspirate', methods=["POST"])
+def aspirate_from_current_position():
+    axis = request.json.get("axis")
+    try:
+        instrument = robot._instruments[axis.upper()]
+        robot.move_head(z=20, mode='relative')
+        instrument.motor.move(instrument.positions['blow_out'])
+        instrument.motor.move(instrument.positions['bottom'])
+        robot.move_head(z=-20, mode='relative')
+        instrument.motor.move(instrument.positions['top'])
+    except Exception as e:
+        emit_notifications([str(e)], 'danger')
+        return flask.jsonify({
+            'status': 'error',
+            'data': str(e)
+        })
+
+    return flask.jsonify({
+        'status': 'success',
+        'data': ''
+    })
+
+
+@app.route('/dispense', methods=["POST"])
+def dispense_from_current_position():
+    axis = request.json.get("axis")
+    try:
+        instrument = robot._instruments[axis.upper()]
+        instrument.motor.move(instrument.positions['blow_out'])
+    except Exception as e:
+        emit_notifications([str(e)], 'danger')
+        return flask.jsonify({
+            'status': 'error',
+            'data': str(e)
+        })
+
+    return flask.jsonify({
+        'status': 'success',
+        'data': ''
+    })
+
+
+@app.route('/set_max_volume', methods=["POST"])
+def set_max_volume():
+    volume = request.json.get("volume")
+    axis = request.json.get("axis")
+    try:
+        instrument = robot._instruments[axis.upper()]
+        instrument.set_max_volume(volume)
+    except Exception as e:
+        emit_notifications([str(e)], 'danger')
+        return flask.jsonify({
+            'status': 'error',
+            'data': str(e)
+        })
+
+    return flask.jsonify({
+        'status': 'success',
+        'data': ''
+    })
+
+
 def _calibrate_placeable(container_name, axis_name):
 
     deck = robot._deck

--- a/server/main.py
+++ b/server/main.py
@@ -581,6 +581,8 @@ def move_to_plunger_position():
 def aspirate_from_current_position():
     axis = request.json.get("axis")
     try:
+        # this action mimics 1.2 app experience
+        # but should be re-thought to take advantage of API features
         instrument = robot._instruments[axis.upper()]
         robot.move_head(z=20, mode='relative')
         instrument.motor.move(instrument.positions['blow_out'])
@@ -604,6 +606,8 @@ def aspirate_from_current_position():
 def dispense_from_current_position():
     axis = request.json.get("axis")
     try:
+        # this action mimics 1.2 app experience
+        # but should be re-thought to take advantage of API features
         instrument = robot._instruments[axis.upper()]
         instrument.motor.move(instrument.positions['blow_out'])
     except Exception as e:

--- a/server/main.py
+++ b/server/main.py
@@ -67,7 +67,6 @@ def load_python(stream):
         print(e)
         api_response['errors'] = [str(e)]
 
-
     api_response['warnings'] = robot.get_warnings() or []
 
     return api_response

--- a/server/tests/data/bad_protocol.py
+++ b/server/tests/data/bad_protocol.py
@@ -31,6 +31,7 @@ p200s = instruments.Pipette(
     trash_container=trash,
     tip_racks=[tiprack],
     min_volume=10,  # These are variable
+    max_volume=200,
     axis="b",
     channels=1
 )
@@ -39,12 +40,11 @@ p10 = instruments.Pipette(
     trash_container=trash,
     tip_racks=[tiprack],
     min_volume=1,  # These are variable
+    max_volume=10,
     axis="a",
     channels=1
 )
-p200.set_max_volume(200)
 p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
-p10.set_max_volume(10)
 p10.calibrate_plunger(top=0, bottom=11, blow_out=13, drop_tip=14)
 
 p200.pick_up_tip(tiprack[0])

--- a/server/tests/data/protocol.py
+++ b/server/tests/data/protocol.py
@@ -30,6 +30,7 @@ p1000 = instruments.Pipette(
     trash_container=trash,
     tip_racks=[tiprack],
     min_volume=10,  # These are variable
+    max_volume=1000,
     axis="b",
     channels=1
 )
@@ -38,15 +39,13 @@ p10 = instruments.Pipette(
     trash_container=trash,
     tip_racks=[tiprack],
     min_volume=1,  # These are variable
+    max_volume=10,
     axis="a",
     channels=1
 )
 
 p1000.delete_calibration_data()
 p10.delete_calibration_data()
-
-p1000.set_max_volume(200)
-p10.set_max_volume(10)
 
 p1000.pick_up_tip(tiprack[0])
 

--- a/server/tests/test_upload.py
+++ b/server/tests/test_upload.py
@@ -161,9 +161,11 @@ class UploadTestCase(unittest.TestCase):
         for key, value in expected_data['data'][0].items():
             if key != 'placeables':
                 self.assertEquals(value, response_data[key])
+                pass
             else:
                 for placeable in value:
                     self.assertTrue(placeable in response_data['placeables'])
+                    pass
 
     def test_upload_invalid_python(self):
         pass


### PR DESCRIPTION
## Description:

This PR adds routes for /aspirate, /dispense, and /set_max_volume

Check List:

- [ ] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [x] added unit tests if necessary
