### PR TITLE
231 s move to slot shouldn t go down at all it should just go to the top ask dagney for more details

### DIFF
--- a/app/renderer/src/components/DeckSlot.vue
+++ b/app/renderer/src/components/DeckSlot.vue
@@ -14,7 +14,7 @@
     props: ["busy"],
     methods: {
       jogToSlot(slot) {
-        this.$store.dispatch("jogToSlot", {slot: slot, axis: "a"})
+        this.$store.dispatch("jogToSlot", {slot: slot})
       }
     },
     computed: {

--- a/server/main.py
+++ b/server/main.py
@@ -482,28 +482,21 @@ def jog():
 @app.route('/move_to_slot', methods=["POST"])
 def move_to_slot():
     status = 'success'
+    result = ''
     try:
         slot = request.json.get("slot")
-        axis = request.json.get("axis")
         slot = robot._deck[slot]
 
-        instrument = robot._instruments.get(axis.upper())
+        slot_x, slot_y, _ = slot.from_center(
+            x=-0.5, y=0, z=0, reference=robot._deck)
+        _, _, robot_max_z = robot._driver.get_dimensions()
 
-        relative_coord = slot.from_center(x=-1.0, y=0, z=0)
-        _, _, tallest_z = slot.max_dimensions(slot)
-        relative_coord += (0, 0, tallest_z)
-        location = (slot, relative_coord)
-
-        result = robot.move_to(
-            location,
-            enqueue=False,
-            instrument=instrument
-        )
+        robot.move_head(z=robot_max_z)
+        robot.move_head(x=slot_x, y=slot_y)
     except Exception as e:
         result = str(e)
         status = 'error'
         emit_notifications([result], 'danger')
-
 
     return flask.jsonify({
         'status': status,

--- a/server/tests/test_calibration.py
+++ b/server/tests/test_calibration.py
@@ -18,6 +18,27 @@ class CalibrationTestCase(unittest.TestCase):
         self.robot = Robot.get_instance()
         self.robot.connect()
 
+    def test_move_to_slot(self):
+        arguments = {
+            'slot': 'A1'
+        }
+        response = self.app.post(
+            '/move_to_slot',
+            data=json.dumps(dict(arguments)),
+            content_type='application/json')
+        status = json.loads(response.data.decode())['status']
+        self.assertEqual(status, 'success')
+
+        arguments = {
+            'slot': 'A4'
+        }
+        response = self.app.post(
+            '/move_to_slot',
+            data=json.dumps(dict(arguments)),
+            content_type='application/json')
+        status = json.loads(response.data.decode())['status']
+        self.assertEqual(status, 'error')
+
     def test_aspirate_dispense(self):
 
         response = self.app.post('/upload', data={


### PR DESCRIPTION
## Description:

Small PR, /move_to_slot will not move the Z axis down at all from the top of machine (same  in 1.2)

Check List:

- [ ] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [x] added unit tests if necessary
