### PR TITLE
Create steplist only after upload

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -162,7 +162,6 @@ def load():
         calibrations = update_step_list()
     except Exception as e:
         emit_notifications([str(e)], "danger")
-        print(str(e))
         status = 'error'
 
     return flask.jsonify({
@@ -198,8 +197,6 @@ def _run_commands():
             error = "This protocol does not contain any commands for the robot."
             api_response['errors'] = [error]
     except Exception as e:
-        print("EXCEPTION")
-        print(str(e))
         api_response['errors'] = [str(e)]
 
     api_response['warnings'] = robot.get_warnings() or []
@@ -545,7 +542,6 @@ def update_step_list():
             for placeable_step in step['placeables']:
                 for c in _get_all_containers():
                     if c.get_name() == placeable_step['label']:
-                        print('three')
                         placeable_step.update({
                             'calibrated': _check_if_calibrated(instrument, c)
                         })

--- a/server/main.py
+++ b/server/main.py
@@ -211,10 +211,6 @@ def _run_commands():
     result = "Run complete in {}".format(run_time)
     emit_notifications([result], 'success')
 
-    if api_response['errors']:
-        # simulate again to reset the robot's state
-        robot.simulate(switches=False)
-
 
 @app.route("/run", methods=["GET"])
 def run():

--- a/server/main.py
+++ b/server/main.py
@@ -503,7 +503,6 @@ current_protocol_step_list = None
 
 def create_step_list():
     global current_protocol_step_list
-    current_protocol_step_list = []
     try:
         current_protocol_step_list = [{
             'axis': instrument.axis,
@@ -518,13 +517,14 @@ def create_step_list():
                 for container in _get_unique_containers(instrument)
             ]
         } for instrument in _get_all_pipettes()]
-
-        return update_step_list()
     except Exception as e:
         emit_notifications([str(e)], 'danger')
 
+    return update_step_list()
+
 
 def update_step_list():
+    global current_protocol_step_list
     if not current_protocol_step_list:
         create_step_list()
     try:
@@ -545,10 +545,10 @@ def update_step_list():
                         placeable_step.update({
                             'calibrated': _check_if_calibrated(instrument, c)
                         })
-
-        return current_protocol_step_list
     except Exception as e:
         emit_notifications([str(e)], 'danger')
+
+    return current_protocol_step_list
 
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -535,8 +535,9 @@ def update_step_list():
                 'calibrated': _check_if_instrument_calibrated(instrument)
             })
 
+            all_containers = _get_all_containers()
             for placeable_step in step['placeables']:
-                for c in _get_all_containers():
+                for c in all_containers:
                     if c.get_name() == placeable_step['label']:
                         placeable_step.update({
                             'calibrated': _check_if_calibrated(instrument, c)


### PR DESCRIPTION
## Description:
This PR creates the calibration step list only after successful upload of a protocol. When the calibration state of an instrument is changed by UI, the step list is updated and returned to UI.

Check List:

- [ ] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [ ] added unit tests if necessary
