### PR TITLE
remove strict vuex store config

### DIFF
--- a/app/renderer/store/store.js
+++ b/app/renderer/store/store.js
@@ -84,6 +84,5 @@ export default new Vuex.Store({
   actions,
   mutations,
   plugins: [websocketplugin],
-  modules: {toast},
-  strict: true
+  modules: {toast}
 })


### PR DESCRIPTION
Removes `strict` option on vuex, which breaks the app in development because we break some Vuex rules. Disabling for now, later we should revisit and fix the warnings that strict brings up.

