### PR TITLE
Toggle webpack target

### DIFF
--- a/app/renderer/components/DeckSlot.vue
+++ b/app/renderer/components/DeckSlot.vue
@@ -19,8 +19,10 @@
     },
     computed: {
       slots () {
-        let baseSlots = ['A2', 'B2', 'C2', 'D2', 'E2',
-                          'A1', 'B1', 'C1', 'D1', 'E1']
+        let baseSlots = [
+          'A2', 'B2', 'C2', 'D2', 'E2',
+          'A1', 'B1', 'C1', 'D1', 'E1'
+        ]
         if (this.$store.state.versions.ot_version) {
           let version = this.$store.state.versions.ot_version.version
           if (version !== 'hood') {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "webpack-dev-server --port 8090 --inline --hot --content-base ./app/renderer",
     "release:posix": "npm run build:backend:posix && npm run build:frontend:posix",
     "release:win": "npm run build:backend:win && npm run build:frontend:win",
-    "start": "cross-env ENABLE_VIRTUAL_SMOOTHIE=true NODE_ENV=development electron app/",
+    "start": "cross-env ENABLE_VIRTUAL_SMOOTHIE=true NODE_ENV=development electron app/ --disable-http-cache",
     "unit": "karma start test/unit/karma.conf.js --single-run",
     "integration": "cross-env ENABLE_VIRTUAL_SMOOTHIE=true mocha --timeout 60000 test/integration_test.js",
     "test": "npm run unit; npm run integration; nosetests"

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -5,7 +5,7 @@
 
 var path = require('path')
 var merge = require('webpack-merge')
-var baseConfig = require('../../webpack.config.js')[0]
+var baseConfig = require('../../webpack.config.js')
 var projectRoot = path.resolve(__dirname, '../../')
 
 var webpackConfig = merge(baseConfig, {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var webpack = require('webpack')
 
-let electronConfig = {
+module.exports = {
   entry: './app/renderer/main.js',
   output: {
     path: path.resolve(__dirname, './server/templates/dist'),
@@ -84,16 +84,8 @@ let electronConfig = {
   },
   headers: { 'Access-Control-Allow-Origin': 'http://localhost:5000', 'Access-Control-Allow-Credentials': 'true' },
   devtool: '#eval-source-map',
-  target: 'electron'
+  target: process.env['APP_TARGET'] || 'electron'
 }
-
-let webConfig = Object.assign({}, electronConfig)
-webConfig['target'] = 'web'
-
-module.exports = [
-  electronConfig,
-  webConfig
-]
 
 if (process.env.NODE_ENV === 'production') {
   module.exports.devtool = '#source-map'


### PR DESCRIPTION
This small PR sets the default webpack target to be Electron, but lets us modify it (mainly for development) to be Web by setting the APP_TARGET environment variable.

It also disables caching on `npm start`, a problem we've had for a while that is a super easy fix.
