### PR TITLE
Protocol load bug fix

### DIFF
--- a/app/renderer/components/Placeable.vue
+++ b/app/renderer/components/Placeable.vue
@@ -70,7 +70,7 @@
       }
     },
     created: function () {
-      if (this.$store.state.tasks) {
+      if (!this.$store.state.tasks[0]) {
         this.$store.dispatch('loadProtocol')
       }
     }

--- a/app/renderer/components/Placeable.vue
+++ b/app/renderer/components/Placeable.vue
@@ -70,7 +70,9 @@
       }
     },
     created: function () {
+      console.log('CREATED')
       if (!this.$store.state.tasks[0]) {
+        console.log('CALLED')
         this.$store.dispatch('loadProtocol')
       }
     }

--- a/app/renderer/components/Placeable.vue
+++ b/app/renderer/components/Placeable.vue
@@ -1,5 +1,5 @@
 <template>
-  <section id='task'>
+  <section id='task' v-if='this.instrument() && this.placeable()'>
     <h1 class='title'>
       Calibrate the {{this.instrument().label}} pipette to the
       {{this.placeable().sanitizedType === 'tiprack' ? 'center' : 'bottom'}}
@@ -70,9 +70,7 @@
       }
     },
     created: function () {
-      console.log('CREATED')
       if (!this.$store.state.tasks[0]) {
-        console.log('CALLED')
         this.$store.dispatch('loadProtocol')
       }
     }

--- a/app/renderer/components/Upload.vue
+++ b/app/renderer/components/Upload.vue
@@ -1,9 +1,9 @@
 <template>
   <span :class='{disabled: busy}'>
-    <form ref='form' @submit='uploadProtocol' action='http://127.0.0.1:5000/upload' method='POST' enctype='multipart/form-data'  class='upload'>
+    <form ref='form' class='upload'>
       <div class='fileUpload'>
         <span>{{this.uploadMessage()}}</span>
-        <input ref='input' @change='fileChange' type='file' name='file' class='upload' />
+        <input ref='input' @change='uploadProtocol' type='file' name='file' class='upload' />
       </div>
     </form>
   </span>
@@ -13,9 +13,6 @@
   export default {
     name: 'Upload',
     methods: {
-      fileChange (e) {
-        this.uploadProtocol()
-      },
       uploadProtocol () {
         let formData = new FormData()
         let file = this.$refs.form.file.files[0]

--- a/app/renderer/store/store.js
+++ b/app/renderer/store/store.js
@@ -18,24 +18,6 @@ function createWebSocketPlugin (socket) {
           store.commit(types.UPDATE_ROBOT_CONNECTION, {'isConnected': false, 'port': null})
         }
       }
-      if (data.name === 'move-finished') {
-        store.commit(types.UPDATE_POSITION, {
-          x: data.position.head.x,
-          y: data.position.head.y,
-          z: data.position.head.z,
-          a: data.position.plunger.a,
-          b: data.position.plunger.b
-        }, { silent: true })
-      }
-      if (data.name === 'home' && data.axis) {
-        store.commit(types.UPDATE_POSITION, {
-          x: data.position.head.x,
-          y: data.position.head.y,
-          z: data.position.head.z,
-          a: data.position.plunger.a,
-          b: data.position.plunger.b
-        })
-      }
       if (data.name === 'command-run') {
         if (data.caller === 'ui') {
           let newDate = new Date()

--- a/test/unit/specs/components/Placeable.spec.js
+++ b/test/unit/specs/components/Placeable.spec.js
@@ -2,14 +2,14 @@
 import { expect } from 'chai'
 import Vue from 'vue'
 import Vuex from 'vuex'
-import sinon from 'sinon'
+// import sinon from 'sinon'
 import Placeable from 'renderer/components/Placeable.vue'
 
 Vue.use(Vuex)
 
 function getMockStore () {
   return {
-    actions: { loadProtocol: sinon.spy() },
+    actions: { loadProtocol: console.log('I M LOADING N ACTION') },
     state: {
       tasks: [
         {
@@ -63,6 +63,16 @@ describe('Placeable.vue', (done) => {
     expect(typeof imageUrl).to.eq('string')
   })
 
+  it('loads a protocol before being created', () => {
+    let emptyStore = getMockStore()
+    emptyStore.state.tasks = []
+    // console.log(emptyStore)
+    // console.log(mockStore)
+    let p = getRenderedVm(Placeable, emptyStore)
+    console.log(p.$store.state.tasks)
+    // expect(mockStore.actions.loadProtocol.called).to.be.true
+  })
+
   it('correctly determins its calibration point', () => {
     expect(getRenderedVm(Placeable, mockStore).calibrationPoint).to.equal('of the A1 well')
 
@@ -87,14 +97,5 @@ describe('Placeable.vue', (done) => {
     let tiprackSingleStore = getMockStore()
     tiprackSingleStore.state.tasks[0].placeables[0].type = 'plate'
     expect(getRenderedVm(Placeable, tiprackSingleStore).calibrationPoint).to.equal('of the A1 well')
-  })
-
-  it('loads a protocol before being created', () => {
-    let emptyStore = getMockStore()
-    emptyStore.state.tasks = []
-    // console.log(emptyStore)
-    // console.log(mockStore)
-    getRenderedVm(Placeable, emptyStore)
-    // expect(mockStore.actions.loadProtocol.called).to.be.true
   })
 })

--- a/test/unit/specs/components/Placeable.spec.js
+++ b/test/unit/specs/components/Placeable.spec.js
@@ -63,11 +63,6 @@ describe('Placeable.vue', (done) => {
     expect(typeof imageUrl).to.eq('string')
   })
 
-  it('loads a protocol before being created', () => {
-    getRenderedVm(Placeable, mockStore)
-    expect(mockStore.actions.loadProtocol.called).to.be.true
-  })
-
   it('correctly determins its calibration point', () => {
     expect(getRenderedVm(Placeable, mockStore).calibrationPoint).to.equal('of the A1 well')
 
@@ -92,5 +87,14 @@ describe('Placeable.vue', (done) => {
     let tiprackSingleStore = getMockStore()
     tiprackSingleStore.state.tasks[0].placeables[0].type = 'plate'
     expect(getRenderedVm(Placeable, tiprackSingleStore).calibrationPoint).to.equal('of the A1 well')
+  })
+
+  it('loads a protocol before being created', () => {
+    let emptyStore = getMockStore()
+    emptyStore.state.tasks = []
+    // console.log(emptyStore)
+    // console.log(mockStore)
+    getRenderedVm(Placeable, emptyStore)
+    // expect(mockStore.actions.loadProtocol.called).to.be.true
   })
 })

--- a/test/unit/specs/components/Placeable.spec.js
+++ b/test/unit/specs/components/Placeable.spec.js
@@ -2,14 +2,14 @@
 import { expect } from 'chai'
 import Vue from 'vue'
 import Vuex from 'vuex'
-// import sinon from 'sinon'
+import sinon from 'sinon'
 import Placeable from 'renderer/components/Placeable.vue'
 
 Vue.use(Vuex)
 
 function getMockStore () {
   return {
-    actions: { loadProtocol: console.log('I M LOADING N ACTION') },
+    actions: { loadProtocol: sinon.spy() },
     state: {
       tasks: [
         {
@@ -63,14 +63,14 @@ describe('Placeable.vue', (done) => {
     expect(typeof imageUrl).to.eq('string')
   })
 
-  it('loads a protocol before being created', () => {
+  it('loads a protocol before being created if there are no tasks', () => {
+    getRenderedVm(Placeable, mockStore)
+    expect(mockStore.actions.loadProtocol.called).to.be.false
+
     let emptyStore = getMockStore()
     emptyStore.state.tasks = []
-    // console.log(emptyStore)
-    // console.log(mockStore)
-    let p = getRenderedVm(Placeable, emptyStore)
-    console.log(p.$store.state.tasks)
-    // expect(mockStore.actions.loadProtocol.called).to.be.true
+    getRenderedVm(Placeable, emptyStore)
+    expect(emptyStore.actions.loadProtocol.calledOnce).to.be.true
   })
 
   it('correctly determins its calibration point', () => {


### PR DESCRIPTION
## Description:
This PR fixes three bugs:
1. Protocol loading was happening on every page load, and not just when it is actually necessary (when there are no tasks but you navigate to a placeable)
2. The Placeable component was displaying before it had a chance to get it's necessary data - to evade this I just have a conditional render that checks for data.
3. The upload component had an entirely unnecessary form submit and accompanying method - this was deprecated by an earlier fix that allowed users to trigger a state change on the reupload of the same file.

Lastly, this PR removes currently unused functions pertaining to the Coordinates component - these can be added back in if/when we decide to merge the Coordinates PR in.

Check List:

- [x] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [x] added unit tests if necessary
