### PR TITLE
Add Run/RunScreen spec, fix socketio bug

### DIFF
--- a/app/renderer/components/RunScreen.vue
+++ b/app/renderer/components/RunScreen.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref='commands' class='runScreen'>
     <h3 @click='clearRunScreen()' id='exit'>x</h3>
-    <div class='runCommand' v-for='command in runLog'>
+    <div class='runCommand' v-for='command in runLog()'>
       {{command.timestamp}} - {{command.command_description}}
       <br>
     </div>
@@ -10,14 +10,12 @@
 
 <script>
   export default {
-    computed: {
-      runLog () {
-        return this.$store.state.runLog
-      }
-    },
     methods: {
       clearRunScreen () {
         this.$store.dispatch('finishRun')
+      },
+      runLog () {
+        return this.$store.state.runLog
       }
     },
     watch: {

--- a/server/main.py
+++ b/server/main.py
@@ -43,7 +43,9 @@ last_modified = "y"
 
 def notify(info):
     s = json.dumps(info, cls=VectorEncoder)
-    socketio.emit('event', json.loads(s))
+    name = json.loads(s).get('name')
+    if name != 'move-finished' and name != 'move-to':
+        socketio.emit('event', json.loads(s))
 
 
 trace.EventBroker.get_instance().add(notify)

--- a/test/unit/specs/components/CalibratePlaceable.spec.js
+++ b/test/unit/specs/components/CalibratePlaceable.spec.js
@@ -25,7 +25,7 @@ let placeable = {
 }
 let instrument = {'axis': 'a'}
 
-describe('CalibratePlaceable.vue', (done) => {
+describe('CalibratePlaceable.vue', () => {
   it('renders pick_up/drop tip if placeable is tiprack', () => {
     expect(getRenderedVm(CalibratePlaceable, {
       placeable,

--- a/test/unit/specs/components/CalibratePlaceable.spec.js
+++ b/test/unit/specs/components/CalibratePlaceable.spec.js
@@ -15,8 +15,6 @@ function getMockStore () {
   }
 }
 
-const mockStore = getMockStore()
-
 let placeable = {
   'slot': 'A1',
   'label': 'tiprack-12ml',
@@ -25,12 +23,14 @@ let placeable = {
 }
 let instrument = {'axis': 'a'}
 
+const mockStore = getMockStore()
+const propsData = { placeable, instrument }
+let calibratePlaceable = getRenderedVm(CalibratePlaceable, propsData, mockStore)
+
 describe('CalibratePlaceable.vue', () => {
   it('renders pick_up/drop tip if placeable is tiprack', () => {
-    expect(getRenderedVm(CalibratePlaceable, {
-      placeable,
-      instrument
-    }).$el.querySelectorAll('button').length).to.equal(4)
+    const buttons = calibratePlaceable.$el.querySelectorAll('button')
+    expect(buttons.length).to.equal(4)
   })
 
   it('does not render tip buttons if placeable is not tiprack', () => {
@@ -54,22 +54,15 @@ describe('CalibratePlaceable.vue', () => {
   })
 
   it('enables all buttons when calibrated', () => {
-    expect(getRenderedVm(CalibratePlaceable, {
-      placeable,
-      instrument
-    }).$el.querySelectorAll('button.disabled').length).to.equal(0)
+    let buttons = calibratePlaceable.$el.querySelectorAll('button.disabled')
+    expect(buttons.length).to.equal(0)
   })
 
   it('calls the correct actions for each button click', () => {
-    let renderedCalibratePlaceable = getRenderedVm(CalibratePlaceable, {
-      placeable,
-      instrument
-    }, mockStore)
-
-    renderedCalibratePlaceable.calibrate()
-    renderedCalibratePlaceable.moveToPosition()
-    renderedCalibratePlaceable.pickUpTip()
-    renderedCalibratePlaceable.dropTip()
+    calibratePlaceable.calibrate()
+    calibratePlaceable.moveToPosition()
+    calibratePlaceable.pickUpTip()
+    calibratePlaceable.dropTip()
 
     expect(mockStore.actions.calibrate.called).to.be.true
     expect(mockStore.actions.moveToPosition.called).to.be.true

--- a/test/unit/specs/components/DeckSlot.spec.js
+++ b/test/unit/specs/components/DeckSlot.spec.js
@@ -22,7 +22,7 @@ const mockStore = getMockStore()
 const propsData = { busy: false }
 const deckSlot = getRenderedVm(DeckSlot, propsData, mockStore)
 
-describe('DeckSlot.vue', (done) => {
+describe('DeckSlot.vue', () => {
   it('renders each slot', () => {
     const slotsLength = deckSlot.slots().length
     expect(deckSlot.$el.querySelectorAll('button').length).to.equal(slotsLength)

--- a/test/unit/specs/components/Home.spec.js
+++ b/test/unit/specs/components/Home.spec.js
@@ -13,7 +13,7 @@ function getMockStore () {
 const mockStore = getMockStore()
 const home = getRenderedVm(Home, {}, mockStore)
 
-describe('Home.vue', (done) => {
+describe('Home.vue', () => {
   it('has 6 btn-home classes', () => {
     expect(home.$el.querySelectorAll('.btn-home').length).to.equal(6)
   })

--- a/test/unit/specs/components/Increment.spec.js
+++ b/test/unit/specs/components/Increment.spec.js
@@ -15,7 +15,7 @@ const mockStore = getMockStore()
 const propsData = { increments: [1, 2, 5, 10] }
 const protocol = getRenderedVm(Increment, propsData, mockStore)
 
-describe('Increment.vue', (done) => {
+describe('Increment.vue', () => {
   it('has a radio button for each increment', () => {
     expect(protocol.$el.querySelectorAll('input').length).to.equal(4)
   })

--- a/test/unit/specs/components/IncrementPlunger.spec.js
+++ b/test/unit/specs/components/IncrementPlunger.spec.js
@@ -15,7 +15,7 @@ const mockStore = getMockStore()
 const propsData = { increments: [1, 2, 5] }
 const protocol = getRenderedVm(IncrementPlunger, propsData, mockStore)
 
-describe('IncrementPlunger.vue', (done) => {
+describe('IncrementPlunger.vue', () => {
   it('has a radio button for each increment', () => {
     expect(protocol.$el.querySelectorAll('input').length).to.equal(3)
   })

--- a/test/unit/specs/components/Placeable.spec.js
+++ b/test/unit/specs/components/Placeable.spec.js
@@ -36,7 +36,7 @@ Placeable.methods.params = () => {
 }
 const placeable = getRenderedVm(Placeable, {}, mockStore)
 
-describe('Placeable.vue', (done) => {
+describe('Placeable.vue', () => {
   it('correctly filters instruments and placeables', () => {
     let pipette = mockStore.state.tasks[0]
     expect(placeable.instrument()).to.equal(pipette)

--- a/test/unit/specs/components/ProgressBar.spec.js
+++ b/test/unit/specs/components/ProgressBar.spec.js
@@ -21,7 +21,7 @@ const mockStore = getMockStore()
 const propsData = { increments: [1, 2, 5, 10] }
 const progressBar = getRenderedVm(ProgressBar, propsData, mockStore)
 
-describe('ProgressBar.vue', (done) => {
+describe('ProgressBar.vue', () => {
   it('determines run percent correctly, leaving out notifications', () => {
     expect(progressBar.runPercent()).to.equal(33)
   })

--- a/test/unit/specs/components/Protocol.spec.js
+++ b/test/unit/specs/components/Protocol.spec.js
@@ -15,7 +15,7 @@ function getMockStore () {
 const mockStore = getMockStore()
 const protocol = getRenderedVm(Protocol, {}, mockStore)
 
-describe('Protocol.vue', (done) => {
+describe('Protocol.vue', () => {
   it('has 2 titles and 2 infos', () => {
     expect(protocol.$el.querySelectorAll('.title').length).to.equal(2)
     expect(protocol.$el.querySelectorAll('.info').length).to.equal(2)

--- a/test/unit/specs/components/Run.spec.js
+++ b/test/unit/specs/components/Run.spec.js
@@ -1,0 +1,111 @@
+/* global describe, it */
+import { expect } from 'chai'
+import sinon from 'sinon'
+import Vue from 'vue'
+import Run from 'renderer/components/Run.vue'
+import { getRenderedVm } from '../../util.js'
+
+function getMockStore () {
+  return {
+    state: {
+      running: false,
+      paused: false,
+      isConnected: true,
+      tasks: [
+        { placeables: [{ calibrated: true }, { calibrated: true }] },
+        { placeables: [{ calibrated: true }, { calibrated: true }] }
+      ]
+    },
+    actions: {
+      runProtocol: sinon.spy(),
+      pauseProtocol: sinon.spy(),
+      resumeProtocol: sinon.spy(),
+      cancelProtocol: sinon.spy()
+    }
+  }
+}
+
+const mockStore = getMockStore()
+const run = getRenderedVm(Run, {}, mockStore)
+
+describe('Run.vue', () => {
+  it('enables everything when calibrated', () => {
+    let buttons = run.$el.querySelectorAll('.disabled')
+    expect(buttons.length).to.equal(0)
+  })
+
+  it('disables everything when not calibrated', () => {
+    let uncalibratedStore = getMockStore()
+    uncalibratedStore.state.tasks[0].placeables[0].calibrated = false
+    const uncalibratedRun = getRenderedVm(Run, {}, uncalibratedStore)
+    let uncalibratedButtons = uncalibratedRun.$el.querySelectorAll('.disabled')
+    Vue.nextTick(() => {
+      expect(uncalibratedButtons.length).to.equal(1)
+    })
+  })
+
+  it('toggles run and cancel based on running being false', () => {
+    let btnRun = run.$el.querySelector('.btn-run')
+    let btnClear = run.$el.querySelector('.btn-clear')
+    expect(btnRun.style.display).to.equal('')
+    expect(btnClear.style.display).to.equal('none')
+  })
+
+  it('toggles run and cancel based on running being true', () => {
+    const nonRunningStore = getMockStore()
+    nonRunningStore.state.running = true
+    const nonRunningRun = getRenderedVm(Run, {}, nonRunningStore)
+    let btnRun = nonRunningRun.$el.querySelector('.btn-run')
+    let btnClear = nonRunningRun.$el.querySelector('.btn-clear')
+    expect(btnRun.style.display).to.equal('none')
+    expect(btnClear.style.display).to.equal('')
+  })
+
+  it('hides pause and resume when not running', () => {
+    let btnPause = run.$el.querySelector('.btn-pause')
+    let btnResume = run.$el.querySelector('.btn-play')
+    expect(btnPause.style.display).to.equal('none')
+    expect(btnResume.style.display).to.equal('none')
+  })
+
+  it('enables pause and disables resume based on pause being true', () => {
+    const nonPausedStore = getMockStore()
+    nonPausedStore.state.paused = true
+    nonPausedStore.state.running = true
+    const nonPausedRun = getRenderedVm(Run, {}, nonPausedStore)
+    let btnPause = nonPausedRun.$el.querySelector('.btn-pause')
+    let btnResume = nonPausedRun.$el.querySelector('.btn-play')
+    expect(btnPause.style.display).to.equal('none')
+    expect(btnResume.style.display).to.equal('')
+  })
+
+  it('disables pause and enables resume based on pause being false', () => {
+    const pausedStore = getMockStore()
+    pausedStore.state.paused = false
+    pausedStore.state.running = true
+    const pausedRun = getRenderedVm(Run, {}, pausedStore)
+    let btnPause = pausedRun.$el.querySelector('.btn-pause')
+    let btnResume = pausedRun.$el.querySelector('.btn-play')
+    expect(btnPause.style.display).to.equal('')
+    expect(btnResume.style.display).to.equal('none')
+  })
+
+  it('clicking each button dispatches the correct action', () => {
+    expect(mockStore.actions.runProtocol.called).to.be.false
+    expect(mockStore.actions.cancelProtocol.called).to.be.false
+    expect(mockStore.actions.pauseProtocol.called).to.be.false
+    expect(mockStore.actions.resumeProtocol.called).to.be.false
+    let btnRun = run.$el.querySelector('.btn-run')
+    let btnClear = run.$el.querySelector('.btn-clear')
+    let btnPause = run.$el.querySelector('.btn-pause')
+    let btnResume = run.$el.querySelector('.btn-play')
+    btnRun.click()
+    expect(mockStore.actions.runProtocol.calledOnce).to.be.true
+    btnClear.click()
+    expect(mockStore.actions.cancelProtocol.calledOnce).to.be.true
+    btnPause.click()
+    expect(mockStore.actions.pauseProtocol.calledOnce).to.be.true
+    btnResume.click()
+    expect(mockStore.actions.resumeProtocol.calledOnce).to.be.true
+  })
+})

--- a/test/unit/specs/components/RunScreen.spec.js
+++ b/test/unit/specs/components/RunScreen.spec.js
@@ -1,0 +1,36 @@
+/* global describe, it */
+import { expect } from 'chai'
+import sinon from 'sinon'
+import RunScreen from 'renderer/components/RunScreen.vue'
+import { getRenderedVm } from '../../util.js'
+
+function getMockStore () {
+  return {
+    state: {
+      runLog: [
+        { timestamp: 'today', description: 'some command' },
+        { timestamp: 'tomorrow', description: 'other command' }
+      ]
+    },
+    actions: { finishRun: sinon.spy() }
+  }
+}
+
+const mockStore = getMockStore()
+const runScreen = getRenderedVm(RunScreen, {}, mockStore)
+
+describe('RunScreen.vue', () => {
+  it('displays each command', () => {
+    const runCommandSelector = runScreen.$el.querySelectorAll('.runCommand')
+    const runLog = mockStore.state.runLog
+    expect(runCommandSelector.length).to.equal(runLog.length)
+  })
+
+  it('has the runLog', () => {
+    // expect(runScreen.$el.querySelectorAll('input').length).to.equal(4)
+  })
+
+  it('dispatches finishRun when the X is clicked', () => {
+    // expect(runScreen.$el.querySelectorAll('input').length).to.equal(4)
+  })
+})

--- a/test/unit/specs/components/RunScreen.spec.js
+++ b/test/unit/specs/components/RunScreen.spec.js
@@ -8,8 +8,8 @@ function getMockStore () {
   return {
     state: {
       runLog: [
-        { timestamp: 'today', description: 'some command' },
-        { timestamp: 'tomorrow', description: 'other command' }
+        { timestamp: 'today', command_description: 'some command' },
+        { timestamp: 'tomorrow', command_description: 'other command' }
       ]
     },
     actions: { finishRun: sinon.spy() }
@@ -24,13 +24,19 @@ describe('RunScreen.vue', () => {
     const runCommandSelector = runScreen.$el.querySelectorAll('.runCommand')
     const runLog = mockStore.state.runLog
     expect(runCommandSelector.length).to.equal(runLog.length)
+    const firstCommand = 'today - some command'
+    const secondCommand = 'tomorrow - other command'
+    expect(runCommandSelector[0].textContent.trim()).to.equal(firstCommand)
+    expect(runCommandSelector[1].textContent.trim()).to.equal(secondCommand)
   })
 
   it('has the runLog', () => {
-    // expect(runScreen.$el.querySelectorAll('input').length).to.equal(4)
+    expect(runScreen.runLog()).to.equal(mockStore.state.runLog)
   })
 
   it('dispatches finishRun when the X is clicked', () => {
-    // expect(runScreen.$el.querySelectorAll('input').length).to.equal(4)
+    const exitSelector = runScreen.$el.querySelector('#exit')
+    exitSelector.click()
+    expect(mockStore.actions.finishRun.calledOnce).to.be.true
   })
 })

--- a/test/unit/specs/components/TaskPane.spec.js
+++ b/test/unit/specs/components/TaskPane.spec.js
@@ -28,7 +28,7 @@ const taskPane = getRenderedVm(TaskPane, propsData, mockStore)
 const busyProps = { busy: true }
 const busyTaskPane = getRenderedVm(TaskPane, busyProps, mockStore)
 
-describe('TaskPane.vue', (done) => {
+describe('TaskPane.vue', () => {
   it('only shows the task pane section when not running', () => {
     expect(taskPane.running()).to.be.true
     const taskPaneSelector = taskPane.$el.querySelector('#task-pane')


### PR DESCRIPTION
## Description:
This PR adds unit tests for the Run and RunScreen components as well as fixes the bug where long protocols would cause toast notifications to be delayed (now we skip movement emits, as they are not needed for now). It also makes some small improvements to other unit tests for readability.

Check List:

- [x] integration tests pass and have sufficient coverage of new changes (`npm run integration`)
- [x] added unit tests if necessary
